### PR TITLE
Use cimg/base:stable instead of circleci/buildpack-deps:stretch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ executors:
     environment:
       IMAGE_NAME: jokkebrok/playground-php-app
     docker:
-      - image: circleci/buildpack-deps:stretch
+      - image: cimg/base:stable
 jobs:
   php-linter:
     docker:


### PR DESCRIPTION
See https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034