### PR TITLE
Move Console tests out of the Unit Tests directory

### DIFF
--- a/app/phpunit.xml
+++ b/app/phpunit.xml
@@ -7,6 +7,9 @@
     <testsuite name="Unit Tests">
       <directory suffix="Test.php">./tests/Unit</directory>
     </testsuite>
+    <testsuite name="Console Tests">
+      <directory suffix="Test.php">./tests/Console</directory>
+    </testsuite>
   </testsuites>
   <php>
     <env name="APP_ENV" value="testing"/>

--- a/app/tests/Console/CloneYearTest.php
+++ b/app/tests/Console/CloneYearTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Unit;
+namespace Tests\Console;
 
 use App\ActivityList;
 use App\AdminSession;

--- a/app/tests/Unit/ExampleTest.php
+++ b/app/tests/Unit/ExampleTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Unit;
 
-use Tests\TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @internal


### PR DESCRIPTION
This makes it clear that unit tests should not be starting the Application.